### PR TITLE
Improve handling of OAuth logins

### DIFF
--- a/SlackUI/Handlers/BrowserRequestHandler.cs
+++ b/SlackUI/Handlers/BrowserRequestHandler.cs
@@ -20,7 +20,7 @@ namespace SlackUI {
 
         private readonly string[] InternalLinkKeywords = { "chrome-devtools" };
 
-        private bool _isSignedIn;
+        private bool IsSignedIn;
 
         #endregion
 
@@ -56,7 +56,7 @@ namespace SlackUI {
             }
 
             // If we have not fully logged in yet, continue to process all requests within Chromium
-            if (!_isSignedIn) {
+            if (!IsSignedIn) {
                 return false;
             }
 
@@ -68,7 +68,7 @@ namespace SlackUI {
 
             // Recognize when we have logged in successfully
             if (request.Url.Contains("/users.setActive")) {
-                _isSignedIn = true;
+                IsSignedIn = true;
             }
 
             // Let the Chromium web browser handle the event

--- a/SlackUI/Handlers/BrowserRequestHandler.cs
+++ b/SlackUI/Handlers/BrowserRequestHandler.cs
@@ -20,6 +20,8 @@ namespace SlackUI {
 
         private readonly string[] InternalLinkKeywords = { "chrome-devtools" };
 
+        private bool _isSignedIn;
+
         #endregion
 
         #region Public Methods
@@ -53,10 +55,20 @@ namespace SlackUI {
                 return true;
             }
 
+            // If we have not fully logged in yet, continue to process all requests within Chromium
+            if (!_isSignedIn) {
+                return false;
+            }
+
             // Launch the default system browser for any link outside of team domain
             if(!request.Url.Contains(Program.ActiveTeamAddress)) {
                 Process.Start(request.Url);
                 return true;
+            }
+
+            // Recognize when we have logged in successfully
+            if (request.Url.Contains("/users.setActive")) {
+                _isSignedIn = true;
             }
 
             // Let the Chromium web browser handle the event


### PR DESCRIPTION
My company uses Google authentication on Slack, which in turn uses our own Active Directory server. This involves a number of requests and redirections to sites outside of slack. SlackUI assumes that all auth occurs on slack.com, and so it sends those requests to the default browser and doesn't end up in an authenticated state itself.

This change just maintains a flag that indicates whether login has completed yet, and contains all handling within Chromium until it does. Currently it detects this by way of looking for "/users.setActive" requests, which is a bit hackish but works well.