### PR TITLE
Automatically log in when launched.

### DIFF
--- a/SlackUI/Core/ApplicationSettings.cs
+++ b/SlackUI/Core/ApplicationSettings.cs
@@ -131,7 +131,7 @@ namespace SlackUI {
                 }
 
                 // Prevent the window height be less than the minimum allowed
-                if(Program.WrapperForm.MinimumSize.Height > windowSize.Width) {
+                if(Program.WrapperForm.MinimumSize.Height > windowSize.Height) {
                     windowSize = new Size(windowSize.Width, Program.WrapperForm.MinimumSize.Height);
                 }
 

--- a/SlackUI/Core/NotificationContext.cs
+++ b/SlackUI/Core/NotificationContext.cs
@@ -70,9 +70,19 @@ namespace SlackUI {
             notifyIcon.Click += notifyIcon_Click;
             notifyIcon.DoubleClick += notifyIcon_DoubleClick;
 
-            // Show the wrapper form on startup?
-            if(Program.Settings.Data.ShowOnStartup) {
+            // Show the team picker form if no team has been set.
+            if (Program.Settings.Data.InitialTeamToLoad.Equals(String.Empty)) {
+                using (TeamPickerForm teamPickerForm = new TeamPickerForm()) {
+                    if (teamPickerForm.ShowDialog() == DialogResult.OK) {
+                        Program.Settings.Data.InitialTeamToLoad = teamPickerForm.SlackTeamDomain;
+                        Program.WrapperForm.Tag = "Initial Load";
+                        Program.WrapperForm.Show();
+                    }
+                }
+            } else if(Program.Settings.Data.ShowOnStartup) {
                 DisplayWrapperForm();
+            } else {
+                LoadFormWithoutDisplaying();
             }
         }
 
@@ -107,6 +117,14 @@ namespace SlackUI {
                     Program.WrapperForm.Show();
                     Program.WrapperForm.Activate();
                 }
+            }
+        }
+
+        private static void LoadFormWithoutDisplaying() {
+            if(Program.WrapperForm.browserPanel.Controls.ContainsKey("initialLoadOverlay")) {
+                Program.WrapperForm.Opacity = 0;
+                Program.WrapperForm.ShowInTaskbar = false;
+                Program.WrapperForm.Show();
             }
         }
 

--- a/SlackUI/Forms/WrapperForm.Designer.cs
+++ b/SlackUI/Forms/WrapperForm.Designer.cs
@@ -83,7 +83,7 @@
 
         #endregion
 
-        private System.Windows.Forms.Panel browserPanel;
+        internal System.Windows.Forms.Panel browserPanel;
         private System.Windows.Forms.Panel initialLoadOverlay;
         private System.Windows.Forms.ProgressBar loadingMarquee;
 

--- a/SlackUI/Forms/WrapperForm.cs
+++ b/SlackUI/Forms/WrapperForm.cs
@@ -67,7 +67,12 @@ namespace SlackUI {
             if(!e.Url.Contains(AboutBlankPage)) {
                 // Remove the initial load overlay from the form
                 this.InvokeOnUiThreadIfRequired(() => {
-                    browserPanel.Controls.RemoveByKey("initialLoadOverlay");
+                    if(browserPanel.Controls.ContainsKey("initialLoadOverlay")) {
+                        browserPanel.Controls.RemoveByKey("initialLoadOverlay");
+                        if (!Program.Settings.Data.ShowOnStartup && (Program.WrapperForm.Tag == null || Program.WrapperForm.Tag.ToString() != "Initial Load")) { Program.WrapperForm.Hide(); }
+                        Program.WrapperForm.ShowInTaskbar = true;
+                        this.Opacity = 1;
+                    }
                 });
 
                 // Unsubscribe the frame load end event


### PR DESCRIPTION
This may not be the most elegant solution, but it works.

As part of this change, I also have the team picker form always showing on load if no team is set.